### PR TITLE
Fixing warning due to unused variable when GPU_MARKERS_V2 is not enabled

### DIFF
--- a/include/PIXEvents.h
+++ b/include/PIXEvents.h
@@ -931,6 +931,7 @@ namespace PIXEventsDetail
             *eventDestination = PIXEncodeEventInfo(0, PIXEvent_EndEvent, eventSize, eventMetadata);
             PIXInsertGPUMarkerOnContextForEndEvent(context, PIXEvent_EndEvent, static_cast<void*>(buffer), static_cast<UINT>(reinterpret_cast<BYTE*>(destination) - reinterpret_cast<BYTE*>(buffer)));
 #else
+            (void)destination;
             PIXEndGPUEventOnContext(context);
 #endif
         }


### PR DESCRIPTION
In `PIXEndEvent`, the `destination` variable is not used when `PIX_USE_GPU_MARKERS_V2` is not enabled. This will emit a warning when compiling with clang and `-Wunused-but-set-variable`.

This PR simply suppresses this warning. 