### PR TITLE
Fix ASAN enablement

### DIFF
--- a/include/PIXEventsCommon.h
+++ b/include/PIXEventsCommon.h
@@ -28,7 +28,9 @@
 #if __has_feature(address_sanitizer)
 #define PIX_ASAN_ENABLED
 #endif
-#elif defined(__SANITIZE_ADDRESS__)
+#endif
+
+#if !defined(PIX_ASAN_ENABLED) && defined(__SANITIZE_ADDRESS__)
 #define PIX_ASAN_ENABLED
 #endif
 


### PR DESCRIPTION
When enabling `PIX_ASAN_ENABLED`, check for `__has_feature` for Clang separately from `__SANITIZE_ADDRESS__` for MSVC.